### PR TITLE
feat: retrieve specific education

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,8 @@
 Flask Application
 '''
 from flask import Flask, jsonify, request
-from models import Experience, Education, Skill
+
+from models import Education, Experience, Skill
 
 app = Flask(__name__)
 
@@ -77,7 +78,7 @@ def get_education(education_id):
             {
                 "message": "education does not exist",
             }
-        )
+        ), 404
 
     record  = existing_education_records[education_id]
     return jsonify(
@@ -85,7 +86,7 @@ def get_education(education_id):
             "message": "education record returned successfully",
             "data": record,
         }
-    )
+    ), 200
 
 
 @app.route('/resume/skill', methods=['GET', 'POST'])

--- a/app.py
+++ b/app.py
@@ -66,6 +66,28 @@ def education():
     return jsonify({})
 
 
+@app.route("/resume/education/<int:education_id>", methods=["GET"])
+def get_education(education_id):
+    '''
+    Handles retrieving specific education 
+    '''
+    existing_education_records = data["education"]
+    if education_id > len(existing_education_records) - 1  :
+        return jsonify(
+            {
+                "message": "education does not exist",
+            }
+        )
+
+    record  = existing_education_records[education_id]
+    return jsonify(
+        {
+            "message": "education record returned successfully",
+            "data": record,
+        }
+    )
+
+
 @app.route('/resume/skill', methods=['GET', 'POST'])
 def skill():
     '''


### PR DESCRIPTION
Fix issue #17 

Add a GET route that allows users to retrieve a specific Education

Endpoint: /resume/education/<int:education_id>

Sample Response:

```
{
  "data": {
    "course": "Computer Science",
    "end_date": "July 2022",
    "grade": "80%",
    "logo": "example-logo.png",
    "school": "University of Tech",
    "start_date": "September 2019"
  },
  "message": "education record returned successfully"
}

```